### PR TITLE
Add GitHub Action for CSS conversion

### DIFF
--- a/.github/workflows/update-css.yml
+++ b/.github/workflows/update-css.yml
@@ -1,0 +1,89 @@
+name: Update CSS
+
+on:
+  release:
+    types: [published]
+    repositories:
+      - sindresorhus/github-markdown-css
+
+jobs:
+  update-css:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Fetch latest release information
+        id: fetch_release
+        run: |
+          latest_release=$(curl -s https://api.github.com/repos/sindresorhus/github-markdown-css/releases/latest)
+          echo "::set-output name=tag::$(echo $latest_release | jq -r .tag_name)"
+          echo "::set-output name=css_url::$(echo $latest_release | jq -r .assets[0].browser_download_url)"
+
+      - name: Download CSS file
+        run: |
+          mkdir -p build
+          curl -L ${{ steps.fetch_release.outputs.css_url }} -o build/github-markdown.css
+
+      - name: Create new branch
+        run: |
+          git checkout -b update-css-${{ steps.fetch_release.outputs.tag }}
+
+      - name: Convert CSS to TailwindCSS
+        run: node convert-to-tailwind.js
+
+      - name: Commit changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git commit -m "Update CSS to version ${{ steps.fetch_release.outputs.tag }}"
+
+      - name: Push changes
+        run: git push --set-upstream origin update-css-${{ steps.fetch_release.outputs.tag }}
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update CSS to version ${{ steps.fetch_release.outputs.tag }}"
+          branch: update-css-${{ steps.fetch_release.outputs.tag }}
+          title: "Update CSS to version ${{ steps.fetch_release.outputs.tag }}"
+          body: "This PR updates the CSS to version ${{ steps.fetch_release.outputs.tag }}."
+
+      - name: Wait for pull request to be merged
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const pr = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            while (pr.data.merged_at === null) {
+              await new Promise(resolve => setTimeout(resolve, 10000));
+              pr = await github.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+              });
+            }
+
+      - name: Create release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.fetch_release.outputs.tag }}
+          release_name: ${{ steps.fetch_release.outputs.tag }}
+          body: |
+            This release updates the CSS to version ${{ steps.fetch_release.outputs.tag }}.
+            Refer to the upstream release notes for more details: https://github.com/sindresorhus/github-markdown-css/releases/tag/${{ steps.fetch_release.outputs.tag }}
+          files: build/github-markdown-tailwind.css

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Node.js dependencies
+node_modules/
+
+# Build directory
+build/
+
+# Environment variables
+.env
+
+# Distribution directory
+dist/
+
+# Log files
+*.log
+
+# Temporary files
+*.tmp
+
+# Cache files
+*.cache
+
+# macOS specific metadata files
+.DS_Store
+
+# Backup files
+*.bak

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # github-markdown-tailwindcss
-GitHub Markdown CSS styles converted into TailwindCSS-formatted styles
+
+GitHub Markdown CSS styles converted into TailwindCSS-formatted styles.
+
+## Configuration
+
+This repository includes a `config.yaml` file in the root directory that allows for flexible configuration of the wrapper style name and other options. The following keys are available in the `config.yaml` file:
+
+* `wrapper_class`: The name of the wrapper class to be used for scoping styles (default: `.md`)
+* `remove_wrapper`: A boolean option to remove the wrapper class altogether (default: `false`)
+* `output_directory`: The directory where the generated Tailwind CSS file will be stored (default: `build`)
+* `file_naming_convention`: The naming convention for the generated Tailwind CSS file (default: `github-markdown-tailwind.css`)
+
+## Usage Guide
+
+1. Clone the repository and navigate to the root directory.
+2. Install the necessary dependencies by running `npm install`.
+3. Customize the `config.yaml` file with your desired configuration options.
+4. Run the conversion script to generate the Tailwind CSS file.
+5. The generated Tailwind CSS file will be stored in the specified output directory.
+
+For more details on how to set up and use Tailwind CSS JIT mode, refer to the official Tailwind CSS documentation.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+wrapper_class: .md
+remove_wrapper: false
+output_directory: build
+file_naming_convention: github-markdown-tailwind.css

--- a/convert-to-tailwind.js
+++ b/convert-to-tailwind.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const postcss = require('postcss');
+const tailwindcss = require('tailwindcss');
+const yaml = require('js-yaml');
+
+// Load configuration from config.yaml
+const config = yaml.load(fs.readFileSync('config.yaml', 'utf8'));
+const wrapperClass = config.wrapper_class || '.md';
+const removeWrapper = config.remove_wrapper || false;
+const outputDirectory = config.output_directory || 'build';
+const fileNamingConvention = config.file_naming_convention || 'github-markdown-tailwind.css';
+
+// Read the downloaded CSS file
+const cssFilePath = path.join(outputDirectory, 'github-markdown.css');
+const cssContent = fs.readFileSync(cssFilePath, 'utf8');
+
+// Process the CSS content with Tailwind CSS JIT mode
+postcss([
+  tailwindcss({
+    mode: 'jit',
+    purge: [cssFilePath],
+    corePlugins: {
+      preflight: false,
+    },
+    theme: {
+      extend: {},
+    },
+    variants: {},
+    plugins: [],
+  }),
+])
+  .process(cssContent, { from: undefined })
+  .then((result) => {
+    let tailwindCssContent = result.css;
+
+    // Add wrapper class if not removed
+    if (!removeWrapper) {
+      tailwindCssContent = `${wrapperClass} { ${tailwindCssContent} }`;
+    }
+
+    // Write the generated Tailwind CSS file
+    const outputFilePath = path.join(outputDirectory, fileNamingConvention);
+    fs.writeFileSync(outputFilePath, tailwindCssContent, 'utf8');
+    console.log(`Generated Tailwind CSS file: ${outputFilePath}`);
+  })
+  .catch((error) => {
+    console.error('Error processing CSS with Tailwind CSS JIT mode:', error);
+  });


### PR DESCRIPTION
Add GitHub Action to automate CSS updates and conversion to TailwindCSS.

* **GitHub Action Workflow**
  - Add `.github/workflows/update-css.yml` to trigger on new releases from `sindresorhus/github-markdown-css`.
  - Fetch latest release information, download CSS file, create new branch, convert CSS to TailwindCSS, and create pull request.
  - Wait for pull request to be merged and create a release with the updated CSS file.

* **Conversion Script**
  - Add `convert-to-tailwind.js` to convert CSS to TailwindCSS using Tailwind CSS JIT mode.
  - Include a dedicated wrapper class (e.g., `.md`) to avoid collisions.
  - Read configuration from `config.yaml` and store the generated Tailwind CSS file in the specified output directory.

* **Configuration File**
  - Add `config.yaml` with keys for `wrapper_class`, `remove_wrapper`, `output_directory`, and `file_naming_convention`.

* **.gitignore**
  - Add `.gitignore` to ignore `node_modules/`, `build/`, `.env`, `dist/`, `*.log`, `*.tmp`, `*.cache`, `.DS_Store`, and `*.bak` files.

* **README.md**
  - Update `README.md` with a detailed description of the repository and a usage guide.
  - Add a section explaining the configuration options available in the `config.yaml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/galligan/github-markdown-tailwindcss/pull/1?shareId=cb180345-5235-4966-8988-45056e9701be).