### PR TITLE
Fix invalid workflow trigger configuration for release events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  repository_dispatch:
+    types: [github-markdown-css-release]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/*

--- a/.github/workflows/watch-external-release.yml
+++ b/.github/workflows/watch-external-release.yml
@@ -1,0 +1,20 @@
+name: Watch External Release
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # Check every 6 hours
+
+jobs:
+  check-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check latest release
+        run: |
+          latest_release=$(curl -s https://api.github.com/repos/sindresorhus/github-markdown-css/releases/latest)
+          latest_tag=$(echo $latest_release | jq -r .tag_name)
+          current_tag=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name || echo "none")
+          if [ "$latest_tag" != "$current_tag" ]; then
+            curl -X POST https://api.github.com/repos/${{ github.repository }}/dispatches \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -d '{"event_type":"github-markdown-css-release"}'


### PR DESCRIPTION
Related to #3

Replace the `release` section with `repository_dispatch` event type in the workflow configuration. Addresses #3

* **.github/workflows/release.yml**
  - Replace the `release` section with `repository_dispatch` event type.
  - Update the `types` to include `github-markdown-css-release`.
  - Remove the `repositories` key.

* **.github/workflows/watch-external-release.yml**
  - Create a new workflow to watch the external repository.
  - Add a `schedule` trigger to check every 6 hours.
  - Add a job to check the latest release from the external repository.
  - Add a step to trigger the `repository_dispatch` event if the latest release is different.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/galligan/github-markdown-tailwindcss/issues/3?shareId=XXXX-XXXX-XXXX-XXXX).